### PR TITLE
Add getIngredientColor interface

### DIFF
--- a/src/control.lua
+++ b/src/control.lua
@@ -64,11 +64,19 @@ local remoteSetIngredientColor = function(name, color)
     researchColor.setIngredientColor(name, color)
 end
 
+local remoteGetIngredientColor = function(name)
+    if not initialized then
+        return
+    end
+    return researchColor.getIngredientColor(name)
+end
+
 remote.add_interface(
     "DiscoScience",
     {
         setLabScale = remoteSetLabScale,
         setIngredientColor = remoteSetIngredientColor,
+        getIngredientColor = remoteGetIngredientColor
     }
 )
 

--- a/src/core/researchColor.lua
+++ b/src/core/researchColor.lua
@@ -33,6 +33,10 @@ researchColor.setIngredientColor = function(name, color)
     researchColor.state.ingredientColors[name] = color
 end
 
+researchColor.getIngredientColor = function(name)
+    return researchColor.state.ingredientColors[name]
+end
+
 researchColor.validateIngredientColors = function()
     if researchColor.state.validated then
         return


### PR DESCRIPTION
For when mods want to take actions based on colors in existing packs, I'm using this in omnimatter_compression to get the colors for existing packs followed by registering the same colors for the variants compression creates.