### PR TITLE
Reload all labs from all surfaces (Fixes #7)

### DIFF
--- a/src/core/labRenderers.lua
+++ b/src/core/labRenderers.lua
@@ -94,8 +94,12 @@ labRenderers.reloadLabs = function ()
     labRenderers.state.labsByForce = {}
     labRenderers.state.labAnimations = {}
     rendering.clear("DiscoScience")
-    for index, lab in ipairs(game.surfaces[1].find_entities_filtered({type = "lab"})) do
-        labRenderers.addLab(lab)
+    for sur in pairs(game.surfaces) do
+        local game_surface = game.get_surface(sur)
+        -- game.print("[DiscoScience] Reloading all Labs on " .. game_surface.name .. " surface") ; Debugging purposes
+        for index, lab in ipairs(game_surface.find_entities_filtered({type = "lab"})) do
+            labRenderers.addLab(lab)
+        end
     end
 end
 
@@ -109,9 +113,11 @@ labRenderers.removeLab = function (entity)
                 labsForForce[labUnitNumber] = nil
             else
                 softErrorReporting.showModError("errors.unregistered-lab-deleted")
+                labRenderers.reloadLabs() -- Force a reload.
             end
         else
             softErrorReporting.showModError("errors.unregistered-lab-deleted")
+            labRenderers.reloadLabs() -- Force a reload.
         end
     end
 end


### PR DESCRIPTION
I'm not entirely sure if the forced reloads within the `removeLab` function are the best, but if they aren't there it doesn't reload at all. 

I also don't know how to package this up into a working mod to test it properly. The method I did to test was to just edit the mod zip directly. Factorio mod dev is new to me and so is Lua.