### PR TITLE
Fix the export script

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
-git archive --format zip --prefix=mod/ --output ../DiscoScience.zip master
+set -euo pipefail
+
+command -v faketorio >/dev/null 2>&1 || {
+    echo "faketorio is required to package the mod" >&2
+    exit 1
+}
+
+faketorio package


### PR DESCRIPTION
Move the files that need to be in the zip into `src/`, and update `export.sh` to actually be able to output a valid mod zip

I'd personally also copy the license file into there, but the currently released version doesn't have it so I won't bother.