### PR TITLE
Use ModData and support custom graphics

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Date: 01. 07. 2026
   Changes:
     - Polish translation (thanks Hacai666!)
     - Require 2.1 (thanks paulvandenburg!)
+    - Support for custom lab animation graphics
   Bugfixes:
     - Actually use the high resolution graphics thanks (thanks PennyJim!)
 ---------------------------------------------------------------------------------------------------

--- a/spec/mocks/prototypes.lua
+++ b/spec/mocks/prototypes.lua
@@ -6,4 +6,6 @@ prototypes.get_technology_filtered = function()
     return game.mockTechPrototypes
 end
 
+--TODO: Need to mock the mod_data
+
 return prototypes

--- a/src/core/labRenderers.lua
+++ b/src/core/labRenderers.lua
@@ -13,28 +13,75 @@ labRenderers.linkState = function (state)
     return state
 end
 
+-- Data validation
+
+--- Return nil to get it removed from the data lookup
+local function validateLabData(lab, data)
+    local labPrototype = prototypes.entity[lab]
+    -- These are logs so stale data in the mod-data isn't a crashable offense
+    if not labPrototype then
+        log("Given lab data for non-existent lab: "..lab.."\t"..serpent.line(data))
+        return nil
+    end
+    if labPrototype.type ~= "lab" then
+        log("Given lab data for a non-lab entity: "..lab)
+        return nil
+    end
+
+    if type(data.animation) ~= "string"
+    or not helpers.is_valid_animation_path(data.animation) then
+        error("Given animation name is not a valid animation: "..lab.." -> "..serpent.line(data.animation))
+    end
+
+    if not data.scale then
+        data.scale = 1
+    elseif type(data.scale) ~= "number" then
+        error("Given animation scale is not a number: "..lab.." -> "..serpent.line(data.scale))
+    end
+
+    return data
+end
+
+local labData = prototypes.mod_data["discoscience-lab-data"].data
+for lab, data in pairs(labData) do
+    labData[lab] = validateLabData(lab, data)
+end
+
 labRenderers.createInitialState = function()
     return {
         labs = {},
         labAnimations = {},
-        labScales = {
-            ["lab"] = 1,
-        }
+        labData = labData,
     }
 end
 
 labRenderers.setLabScale = function (name, scale)
-    labRenderers.state.labScales[name] = scale
+    if not scale then
+        labRenderers.state.labData[name] = nil
+        return
+    elseif type(scale) ~= "number" then
+        error("Given animation scale is not a number: "..serpent.line(scale))
+    end
+
+    local labData = labRenderers.state.labData[name]
+    if not labData then
+        labRenderers.state.labData[name] = {
+            animation = "discoscience-lab-storm",
+            scale = scale,
+        }
+    else
+        labData.scale = scale
+    end
 end
 
 labRenderers.createAnimation = function (entity)
-    local scale = labRenderers.state.labScales[entity.name]
+    local labData = labRenderers.state.labData[entity.name]
     labRenderers.state.labAnimations[entity.unit_number] = draw_animation({
-        animation = "discoscience/lab-storm",
+        animation = labData.animation,
         surface = entity.surface,
         target = entity,
-        x_scale = scale,
-        y_scale = scale,
+        x_scale = labData.scale,
+        y_scale = labData.scale,
         render_layer = "higher-object-under",
         animation_offset = random(300)-1, -- `random()` is [0,1), but `random(m)` is [1,m]
         visible = false,
@@ -43,10 +90,7 @@ end
 
 labRenderers.isCompatibleLab = function (entity)
     if not entity.type == "lab" then return false end
-    for name, _ in pairs(labRenderers.state.labScales) do
-        if entity.name == name then return true end
-    end
-    return false
+    return labRenderers.state.labData[entity.name] and true or false
 end
 
 labRenderers.addLab = function (entity)

--- a/src/core/researchColor.lua
+++ b/src/core/researchColor.lua
@@ -13,6 +13,41 @@ researchColor.linkState = function (state)
     return state
 end
 
+function researchColor.validateColor(color)
+    local possibleColor = {
+        r = color.r or color[1],
+        g = color.g or color[2],
+        b = color.b or color[3],
+        a = color.a or color[4],
+    }
+    local is_255, has_value, outside_bounds = false, false, false
+    for _, value in pairs(possibleColor) do
+        has_value = true
+        if value < 0 or value > 255 then
+            outside_bounds = true
+            break
+        end
+        if value > 1 then is_255 = true end
+    end
+
+    if outside_bounds or not has_value then
+        return nil
+    end
+
+    if is_255 then
+        for key, value in pairs(possibleColor) do
+            possibleColor[key] = value / 255
+        end
+    end
+
+    local alpha = possibleColor.a or 1
+    return {
+        r = (possibleColor.r or 0) * alpha,
+        g = (possibleColor.g or 0) * alpha,
+        b = (possibleColor.b or 0) * alpha,
+    }
+end
+
 researchColor.createInitialState = function()
     return {
         validated = false,
@@ -35,7 +70,13 @@ researchColor.createInitialState = function()
 end
 
 researchColor.setIngredientColor = function(name, color)
-    researchColor.state.ingredientColors[name] = color
+    if not color then
+        researchColor.state.ingredientColors[name] = nil
+    end
+
+    local validColor = researchColor.validateColor(color)
+    if not validColor then error("Invalid color given") end
+    researchColor.state.ingredientColors[name] = validColor
 end
 
 researchColor.getIngredientColor = function(name)

--- a/src/core/researchColor.lua
+++ b/src/core/researchColor.lua
@@ -13,6 +13,8 @@ researchColor.linkState = function (state)
     return state
 end
 
+--- data validation
+
 function researchColor.validateColor(color)
     local possibleColor = {
         r = color.r or color[1],
@@ -48,24 +50,35 @@ function researchColor.validateColor(color)
     }
 end
 
+local function validateSciencePack(item, color)
+    local itemPrototype = prototypes.item[item]
+    -- These are logs so stale data in the mod-data isn't a crashable offense
+    if not itemPrototype then
+        log("Given a color for a non-existent item: "..item.." - "..serpent.line(color))
+        return nil
+    end
+    if not itemPrototype.used_by_labs then
+        log("Given a color for a non-science pack item: "..item.." - "..serpent.line(color))
+        return nil
+    end
+
+    local validColor = researchColor.validateColor(color)
+    if not validColor then
+        error("Given item color was not a valid color: "..item.." - "..serpent.line(color))
+    end
+    return validColor
+end
+
+local ingredientColors = prototypes.mod_data["discoscience-science-colors"].data
+for item, color in pairs(ingredientColors) do
+    ingredientColors[item] = validateSciencePack(item, color)
+end
+
 researchColor.createInitialState = function()
     return {
         validated = false,
         researchColors = {},
-        ingredientColors = {
-            ["automation-science-pack"] =      {r = 0.91, g = 0.16, b = 0.20},
-            ["logistic-science-pack"] =        {r = 0.29, g = 0.97, b = 0.31},
-            ["chemical-science-pack"] =        {r = 0.28, g = 0.93, b = 0.95},
-            ["production-science-pack"] =      {r = 0.83, g = 0.06, b = 0.92},
-            ["military-science-pack"] =        {r = 0.50, g = 0.10, b = 0.50},
-            ["utility-science-pack"] =         {r = 0.96, g = 0.93, b = 0.30},
-            ["space-science-pack"] =           {r = 0.80, g = 0.80, b = 0.80},
-            ["agricultural-science-pack"] =    {r = 0.84, g = 0.84, b = 0.15},
-            ["metallurgic-science-pack"] =     {r = 0.99, g = 0.50, b = 0.04},
-            ["electromagnetic-science-pack"] = {r = 0.89, g = 0.00, b = 0.56},
-            ["cryogenic-science-pack"] =       {r = 0.14, g = 0.18, b = 0.74},
-            ["promethium-science-pack"] =      {r = 0.10, g = 0.10, b = 0.50},
-        },
+        ingredientColors = ingredientColors,
     }
 end
 

--- a/src/data.lua
+++ b/src/data.lua
@@ -1,11 +1,15 @@
+require("prototypes.modData")
 local labChanges = require("prototypes.labChanges")
 
 _G.DiscoScience = {}
 
-_G.DiscoScience.prepareLab = function (lab)
-    labChanges.prepareLab(lab)
-end
+_G.DiscoScience.prepareLab = labChanges.prepareLab
 
-labChanges.prepareLab(data.raw["lab"]["lab"])
+-- Note, this instance doesn't require the full data argument because it is the defaults
+-- But because it's an example, it should show what you can set.
+labChanges.prepareLab(data.raw["lab"]["lab"], {
+    animation = "discoscience/lab-storm",
+    scale = 1,
+})
 
 data:extend{labChanges.labStorm}

--- a/src/prototypes/labChanges.lua
+++ b/src/prototypes/labChanges.lua
@@ -1,6 +1,24 @@
 local labChanges = {}
 
-labChanges.prepareLab = function (lab)
+local labData = data.raw["mod-data"]["discoscience-lab-data"].data
+
+labChanges.prepareLab = function (lab, data)
+    if not data then
+        data = {
+            animation = "discoscience/lab-storm",
+            scale = 1,
+        }
+    else
+        if not data.animation then
+            data.animation = "discoscience/lab-storm"
+        end
+        if not data.scale then
+            data.scale = 1
+        end
+    end
+
+    labData[lab.name] = data
+
     lab.on_animation = lab.off_animation
     lab.created_effect = {
         type = "direct",

--- a/src/prototypes/modData.lua
+++ b/src/prototypes/modData.lua
@@ -1,0 +1,33 @@
+---@class LabData
+---@field scale? double
+---@field animation string Name of an animation prototype
+
+data:extend{
+    {
+        type = "mod-data",
+        name = "discoscience-lab-data",
+        data_type = "ds-lab-data",
+        ---@type table<data.EntityID, LabData>
+        data = {},
+    },
+    {
+        type = "mod-data",
+        name = "discoscience-science-colors",
+        data_type = "ds-science-colors",
+        ---@type table<data.ItemID, Color>
+        data = {
+            ["automation-science-pack"] =      {r = 0.91, g = 0.16, b = 0.20},
+            ["logistic-science-pack"] =        {r = 0.29, g = 0.97, b = 0.31},
+            ["chemical-science-pack"] =        {r = 0.28, g = 0.93, b = 0.95},
+            ["production-science-pack"] =      {r = 0.83, g = 0.06, b = 0.92},
+            ["military-science-pack"] =        {r = 0.50, g = 0.10, b = 0.50},
+            ["utility-science-pack"] =         {r = 0.96, g = 0.93, b = 0.30},
+            ["space-science-pack"] =           {r = 0.80, g = 0.80, b = 0.80},
+            ["agricultural-science-pack"] =    {r = 0.84, g = 0.84, b = 0.15},
+            ["metallurgic-science-pack"] =     {r = 0.99, g = 0.50, b = 0.04},
+            ["electromagnetic-science-pack"] = {r = 0.89, g = 0.00, b = 0.56},
+            ["cryogenic-science-pack"] =       {r = 0.14, g = 0.18, b = 0.74},
+            ["promethium-science-pack"] =      {r = 0.10, g = 0.10, b = 0.50},
+        }
+    }
+}


### PR DESCRIPTION
This is based on #13 because it moves the changelog file and this pr adds an entry to it.

This converts the base behavior of ingredient colors and lab scales to be data stage information. This keeps the remote interfaces for backwards compatibility, but with an assumption that they'll be removed with 2.1.

This also adds an option to reference an animation prototype when preparing a lab for DiscoScience's interactions, allowing for custom lab animations.